### PR TITLE
RF-19901 Use DockerHub user for pulling down images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,12 @@
-version: 2
+version: 2.1
+
 jobs:
   test:
     docker:
       - image: circleci/ruby:2.7.1
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_TOKEN
     steps:
       - checkout
       - run:
@@ -28,6 +32,9 @@ jobs:
   push_to_rubygems:
     docker:
       - image: circleci/ruby:2.7.1
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_TOKEN
     steps:
       - checkout
       - run:
@@ -53,6 +60,8 @@ workflows:
             tags:
               only:
                 - /^v.*/
+          context:
+            - DockerHub
       - push_to_rubygems:
           requires:
             - test
@@ -63,3 +72,5 @@ workflows:
             tags:
               only:
                 - /^v.*/
+          context:
+            - DockerHub


### PR DESCRIPTION
Docker are changing their TOS to rate limit unauthenticated `docker pull`
from the start of November. The rate limiting is based on IP, so builds on
Circle will be immediately impacted. Use a paid-for account and contexts to
configure a user to pull down docker images for CI/CD.
